### PR TITLE
Fixed issues with install procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ systemctl --user status rclone-proton.mount.service
 
 ---
 
+## 🔁 Remount
+
+If unmounted the Proton Drive can be remounted by:
+
+```bash
+systemctl --user restart rclone-proton.mount.service
+```
+
+Note the Proton Drive is mounted each time you login automatically.
+
 ## 🧼 Uninstall
 
 To remove the auto-mount setup:

--- a/setup-proton-mount.sh
+++ b/setup-proton-mount.sh
@@ -4,7 +4,6 @@
 REMOTE_NAME="proton"
 MOUNT_POINT="$HOME/ProtonDrive"
 SYSTEMD_UNIT="$HOME/.config/systemd/user/rclone-proton.mount.service"
-RCLONE_BIN="/usr/local/bin/rclone"
 LOG_DIR="$HOME/.cache/rclone"
 LOG_FILE="$LOG_DIR/rclone-proton.log"
 
@@ -22,7 +21,7 @@ Wants=network-online.target
 
 [Service]
 Type=notify
-ExecStart=$RCLONE_BIN mount $REMOTE_NAME: $MOUNT_POINT \\
+ExecStart=rclone mount $REMOTE_NAME: $MOUNT_POINT \\
     --vfs-cache-mode writes \\
     --vfs-cache-max-size 500M \\
     --vfs-cache-max-age 1h \\

--- a/setup-proton-mount.sh
+++ b/setup-proton-mount.sh
@@ -25,7 +25,7 @@ ExecStart=rclone mount $REMOTE_NAME: $MOUNT_POINT \\
     --vfs-cache-mode writes \\
     --vfs-cache-max-size 500M \\
     --vfs-cache-max-age 1h \\
-    --dir-cache-time 12h \\
+    --dir-cache-time 5m \\
     --poll-interval 1m \\
     --log-level INFO \\
     --log-file $LOG_FILE \\

--- a/setup-proton-mount.sh
+++ b/setup-proton-mount.sh
@@ -45,8 +45,14 @@ if ! grep -q "^user_allow_other" /etc/fuse.conf 2>/dev/null; then
     sudo sh -c 'echo "user_allow_other" >> /etc/fuse.conf'
 fi
 
-# Step 4: Add user to fuse group if not already
-if ! groups | grep -qw fuse; then
+# Step 4a: Check if the fuse group exists, create if not
+if ! cat /etc/group | grep -qw 'fuse'; then
+    echo "[+] Creating 'fuse' group (requires sudo)..."
+    sudo groupadd fuse
+fi
+
+# Step 4b: Add user to fuse group if not already
+if ! groups "$USER" | grep -qw fuse; then
     echo "[+] Adding user to 'fuse' group (requires sudo)..."
     sudo usermod -aG fuse "$USER"
     echo "[!] Please log out and back in for group changes to apply."


### PR DESCRIPTION
# Changes

- Changed `/usr/local/bin/rclone` to `rclone` as the install location will be different for each user, and it should be in the path.
- There was a bug in the current check for the fuse group, which caused the script always to add the user to the fuse group. This should now be fixed.
- Installing fuse does not guarantee there is a fuse group. I added an if statement to check this and create the fuse group if necessary.
- I added instructions to the README on how to restart the service without logging off and on again if the drive is unmounted.
- I reduced the default cache duration so that file changes made remotely now sync within 5 minutes and not 12 hours.